### PR TITLE
Add `pkgconf` as required package

### DIFF
--- a/Formula/vivictpp.rb
+++ b/Formula/vivictpp.rb
@@ -9,6 +9,7 @@ class Vivictpp < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
 
   depends_on "sdl2"
   depends_on "sdl2_ttf"


### PR DESCRIPTION
Clean install, vivict is unable to find `libavformat` due to `Pkg-config for machine host machine not found. Giving up.`. Running `brew install pkgconf` resolves the issue.

Full log:
```
~ brew install vivictpp
==> Fetching vivictorg/vivictpp/vivictpp
==> Downloading https://github.com/vivictorg/vivictpp/archive/refs/tags/v1.1.0.tar.gz
Already downloaded: /Users/z/Library/Caches/Homebrew/downloads/ebaf6b51ce7cd9a05aebf56b866354c95e8f97d7cb73444b644fa1bedda09a33--vivictpp-1.1.0.tar.gz
==> Installing vivictpp from vivictorg/vivictpp
==> Downloading https://formulae.brew.sh/api/formula.jws.json
==> meson builddir
Last 15 lines from /Users/z/Library/Logs/Homebrew/vivictpp/01.meson:
platformfolders| C++ compiler for the host machine: clang++ (clang 16.0.0 "Apple clang version 16.0.0 (clang-1600.0.26.6)")
platformfolders| C++ linker for the host machine: clang++ ld64 1115.7.3
platformfolders| Build targets in project: 8
platformfolders| Subproject platformfolders finished.

Dependency zlib found: YES 1.2.12 (cached)
sdl2-config found: YES (/usr/local/opt/sdl2/bin/sdl2-config) 2.30.11
Run-time dependency sdl2 found: YES 2.30.11
Run-time dependency sdl2_ttf found: YES 2.24.0
Run-time dependency libavformat found: NO (tried framework and cmake)

meson.build:58:20: ERROR: Dependency lookup for libavformat with method 'pkgconfig' failed: Pkg-config for machine host machine not found. Giving up.

A full log can be found at /private/tmp/vivictpp-20250129-28943-clc92b/vivictpp-1.1.0/builddir/meson-logs/meson-log.txt
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.

If reporting this issue please do so at (not Homebrew/brew or Homebrew/homebrew-core):
  https://github.com/vivictorg/homebrew-vivictpp/issues

~ brew install pkgconfig
==> Downloading https://formulae.brew.sh/api/cask.jws.json
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/manifests/2.3.0_1-1
################################################################################################################################################################################## 100.0%
==> Fetching pkgconf
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/blobs/sha256:fb3a6a6fcba8172e5e7512080ff0fb802526e4a93c384508d2e4031bd297e697
################################################################################################################################################################################## 100.0%
==> Pouring pkgconf--2.3.0_1.sonoma.bottle.1.tar.gz
🍺  /usr/local/Cellar/pkgconf/2.3.0_1: 27 files, 327.8KB
==> Running `brew cleanup pkgconf`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

~ brew install vivictpp
==> Fetching vivictorg/vivictpp/vivictpp
==> Downloading https://github.com/vivictorg/vivictpp/archive/refs/tags/v1.1.0.tar.gz
Already downloaded: /Users/z/Library/Caches/Homebrew/downloads/ebaf6b51ce7cd9a05aebf56b866354c95e8f97d7cb73444b644fa1bedda09a33--vivictpp-1.1.0.tar.gz
==> Installing vivictpp from vivictorg/vivictpp
==> meson builddir
==> meson compile -C builddir
🍺  /usr/local/Cellar/vivictpp/1.1.0: 8 files, 2.5MB, built in 1 minute 33 seconds
==> Running `brew cleanup vivictpp`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```